### PR TITLE
HCK-10544: `$collstats` error AWS

### DIFF
--- a/forward_engineering/helpers/applyToInstanceHelper.js
+++ b/forward_engineering/helpers/applyToInstanceHelper.js
@@ -54,7 +54,7 @@ const applyToInstanceHelper = {
 		try {
 			logger.clear();
 			log.info(getSystemInfo(connectionInfo.appVersion));
-			log.info(connectionInfo);
+			log.info(connectionInfo, 'connectionInfo');
 
 			await connectionHelper.connect(connectionInfo, sshService);
 			connectionHelper.close(sshService);

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -22,7 +22,7 @@ module.exports = {
 		try {
 			logger.clear();
 			log.info(getSystemInfo(connectionInfo.appVersion));
-			log.info(connectionInfo);
+			log.info(connectionInfo, 'connectionInfo');
 
 			await connectionHelper.connect(connectionInfo, sshService);
 
@@ -58,7 +58,7 @@ module.exports = {
 
 			logger.clear();
 			log.info(getSystemInfo(connectionInfo.appVersion));
-			log.info(connectionInfo);
+			log.info(connectionInfo, 'connectionInfo');
 
 			const includeSystemCollection = connectionInfo.includeSystemCollection;
 			const connection = await connectionHelper.connect(connectionInfo, sshService);

--- a/shared/logHelper.js
+++ b/shared/logHelper.js
@@ -45,8 +45,8 @@ const toTime = number => {
 
 const createLogger = ({ title, logger, hiddenKeys }) => {
 	return {
-		info(message) {
-			logger.log('info', { message }, title, hiddenKeys);
+		info(message, infoTitle) {
+			logger.log('info', message, infoTitle || title, hiddenKeys);
 		},
 
 		progress(message, dbName = '', tableName = '') {

--- a/shared/mongoDbClient.js
+++ b/shared/mongoDbClient.js
@@ -222,13 +222,8 @@ const createConnection = ({ connection }) => {
 		});
 	};
 
-	const getCountByDirectCommand = ({ db, collectionName, scale = 1000000 }) => {
-		return new Promise((resolve, reject) => {
-			db.command({ collStats: collectionName, scale })
-				.then(resolve)
-				.catch(err => reject(getError(err)));
-		});
-	};
+	const getCountByDirectCommand = ({ db, collectionName, scale = 1000000 }) =>
+		db.command({ collStats: collectionName, scale }).catch(err => Promise.reject(getError(err)));
 
 	const getCount = (dbName, collectionName) => {
 		return new Promise((resolve, reject) => {
@@ -241,7 +236,7 @@ const createConnection = ({ connection }) => {
 				}
 
 				if (err.message.includes('Unrecognized pipeline stage name: $collStats')) {
-					resolve(getCountByDirectCommand({ db, collectionName }));
+					return getCountByDirectCommand({ db, collectionName }).then(resolve).catch(reject);
 				}
 
 				return reject(getError(err));

--- a/shared/mongoDbClient.js
+++ b/shared/mongoDbClient.js
@@ -222,17 +222,29 @@ const createConnection = ({ connection }) => {
 		});
 	};
 
+	const getCountByDirectCommand = ({ db, collectionName, scale = 1000000 }) => {
+		return new Promise((resolve, reject) => {
+			db.command({ collStats: collectionName, scale })
+				.then(resolve)
+				.catch(err => reject(getError(err)));
+		});
+	};
+
 	const getCount = (dbName, collectionName) => {
 		return new Promise((resolve, reject) => {
 			const db = connection.db(dbName);
 			const collection = db.collection(collectionName);
 
 			collection.estimatedDocumentCount((err, count) => {
-				if (err) {
-					return reject(getError(err));
-				} else {
+				if (!err) {
 					return resolve(count);
 				}
+
+				if (err.message.includes('Unrecognized pipeline stage name: $collStats')) {
+					resolve(getCountByDirectCommand({ db, collectionName }));
+				}
+
+				return reject(getError(err));
 			});
 		});
 	};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10544" title="HCK-10544" target="_blank"><img alt="Sub-bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-10544</a>  Documents count failed to fetch using a built-in `$collStats` pipeline
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* handled unsupported pipeline of getting documents count on AWS with a direct invoke of a similar command