### PR TITLE
[HCK-10544] Use enclosed ipv6 addresses

### DIFF
--- a/shared/mongoDbClient.js
+++ b/shared/mongoDbClient.js
@@ -23,7 +23,7 @@ const getSshConnectionSettings = async ({ connectionInfo, sshService }) => {
 	const { options } = await sshService.openTunnel(sshConnectionConfig);
 	return {
 		...connectionInfo,
-		host: options.host,
+		host: options.escapedHostForUrl,
 		port: options.port.toString() || '22',
 	};
 };


### PR DESCRIPTION
## Content

- Mongodb client is using url connection string and requires ipv6 addresses to be enclosed in square brackets.

Requires https://github.com/hackolade/studio/pull/2955