### PR TITLE
HCK-10565: DocumentDB missing meta info

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,8 @@
             "enableREQueryAndSortCriteria": true,
             "relationships": {
                 "entityNameSeparator": "."
-            }
+            },
+			"checkAwsCredentials": true
         }
     },
     "description": "Hackolade plugin for Amazon DocumentDB",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10565" title="HCK-10565" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10565</a>  Add disclaimer if instance metadata won't be fetched
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* introduced AWS credentials check feature flag

## Related PR's

* https://github.com/hackolade/studio/pull/2973