### PR TITLE
HCK-10566: AWS credentials monitoring

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
     "name": "DocumentDB",
-    "version": "0.2.2",
+    "version": "0.2.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "DocumentDB",
-            "version": "0.2.2",
+            "version": "0.2.5",
             "dependencies": {
                 "@aws-sdk/client-docdb": "3.687.0",
+                "@aws-sdk/credential-providers": "3.778.0",
                 "@hackolade/fetch": "1.1.0",
                 "async": "3.2.6",
                 "bson": "1.1.6",
@@ -151,6 +152,989 @@
             },
             "engines": {
                 "node": ">=14.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.777.0.tgz",
+            "integrity": "sha512-VGtFI3SH+jKfPln+9CM16F9zKieIqSxUSZNzQ6WZahPDVC79VmlG6QkXCqgm9Y4qZf4ebcdMhO23+FkR4s9vhA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/credential-provider-node": "3.777.0",
+                "@aws-sdk/middleware-host-header": "3.775.0",
+                "@aws-sdk/middleware-logger": "3.775.0",
+                "@aws-sdk/middleware-recursion-detection": "3.775.0",
+                "@aws-sdk/middleware-user-agent": "3.775.0",
+                "@aws-sdk/region-config-resolver": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.775.0",
+                "@aws-sdk/util-user-agent-browser": "3.775.0",
+                "@aws-sdk/util-user-agent-node": "3.775.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/hash-node": "^4.0.2",
+                "@smithy/invalid-dependency": "^4.0.2",
+                "@smithy/middleware-content-length": "^4.0.2",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-retry": "^4.1.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.8",
+                "@smithy/util-defaults-mode-node": "^4.0.8",
+                "@smithy/util-endpoints": "^3.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/client-sso": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.777.0.tgz",
+            "integrity": "sha512-0+z6CiAYIQa7s6FJ+dpBYPi9zr9yY5jBg/4/FGcwYbmqWPXwL9Thdtr0FearYRZgKl7bhL3m3dILCCfWqr3teQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/middleware-host-header": "3.775.0",
+                "@aws-sdk/middleware-logger": "3.775.0",
+                "@aws-sdk/middleware-recursion-detection": "3.775.0",
+                "@aws-sdk/middleware-user-agent": "3.775.0",
+                "@aws-sdk/region-config-resolver": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.775.0",
+                "@aws-sdk/util-user-agent-browser": "3.775.0",
+                "@aws-sdk/util-user-agent-node": "3.775.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/hash-node": "^4.0.2",
+                "@smithy/invalid-dependency": "^4.0.2",
+                "@smithy/middleware-content-length": "^4.0.2",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-retry": "^4.1.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.8",
+                "@smithy/util-defaults-mode-node": "^4.0.8",
+                "@smithy/util-endpoints": "^3.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/core": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.775.0.tgz",
+            "integrity": "sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/signature-v4": "^5.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.775.0.tgz",
+            "integrity": "sha512-6ESVxwCbGm7WZ17kY1fjmxQud43vzJFoLd4bmlR+idQSWdqlzGDYdcfzpjDKTcivdtNrVYmFvcH1JBUwCRAZhw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.775.0.tgz",
+            "integrity": "sha512-PjDQeDH/J1S0yWV32wCj2k5liRo0ssXMseCBEkCsD3SqsU8o5cU82b0hMX4sAib/RkglCSZqGO0xMiN0/7ndww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-stream": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.777.0.tgz",
+            "integrity": "sha512-1X9mCuM9JSQPmQ+D2TODt4THy6aJWCNiURkmKmTIPRdno7EIKgAqrr/LLN++K5mBf54DZVKpqcJutXU2jwo01A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/credential-provider-env": "3.775.0",
+                "@aws-sdk/credential-provider-http": "3.775.0",
+                "@aws-sdk/credential-provider-process": "3.775.0",
+                "@aws-sdk/credential-provider-sso": "3.777.0",
+                "@aws-sdk/credential-provider-web-identity": "3.777.0",
+                "@aws-sdk/nested-clients": "3.777.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.777.0.tgz",
+            "integrity": "sha512-ZD66ywx1Q0KyUSuBXZIQzBe3Q7MzX8lNwsrCU43H3Fww+Y+HB3Ncws9grhSdNhKQNeGmZ+MgKybuZYaaeLwJEQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.775.0",
+                "@aws-sdk/credential-provider-http": "3.775.0",
+                "@aws-sdk/credential-provider-ini": "3.777.0",
+                "@aws-sdk/credential-provider-process": "3.775.0",
+                "@aws-sdk/credential-provider-sso": "3.777.0",
+                "@aws-sdk/credential-provider-web-identity": "3.777.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.775.0.tgz",
+            "integrity": "sha512-A6k68H9rQp+2+7P7SGO90Csw6nrUEm0Qfjpn9Etc4EboZhhCLs9b66umUsTsSBHus4FDIe5JQxfCUyt1wgNogg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.777.0.tgz",
+            "integrity": "sha512-9mPz7vk9uE4PBVprfINv4tlTkyq1OonNevx2DiXC1LY4mCUCNN3RdBwAY0BTLzj0uyc3k5KxFFNbn3/8ZDQP7w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.777.0",
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/token-providers": "3.777.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.777.0.tgz",
+            "integrity": "sha512-uGCqr47fnthkqwq5luNl2dksgcpHHjSXz2jUra7TXtFOpqvnhOW8qXjoa1ivlkq8qhqlaZwCzPdbcN0lXpmLzQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/nested-clients": "3.777.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz",
+            "integrity": "sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz",
+            "integrity": "sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz",
+            "integrity": "sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.775.0.tgz",
+            "integrity": "sha512-7Lffpr1ptOEDE1ZYH1T78pheEY1YmeXWBfFt/amZ6AGsKSLG+JPXvof3ltporTGR2bhH/eJPo7UHCglIuXfzYg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.775.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz",
+            "integrity": "sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/token-providers": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.777.0.tgz",
+            "integrity": "sha512-Yc2cDONsHOa4dTSGOev6Ng2QgTKQUEjaUnsyKd13pc/nLLz/WLqHiQ/o7PcnKERJxXGs1g1C6l3sNXiX+kbnFQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/nested-clients": "3.777.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/types": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
+            "integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.775.0.tgz",
+            "integrity": "sha512-yjWmUgZC9tUxAo8Uaplqmq0eUh0zrbZJdwxGRKdYxfm4RG6fMw1tj52+KkatH7o+mNZvg1GDcVp/INktxonJLw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-endpoints": "^3.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz",
+            "integrity": "sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.775.0.tgz",
+            "integrity": "sha512-N9yhTevbizTOMo3drH7Eoy6OkJ3iVPxhV7dwb6CMAObbLneS36CSfA6xQXupmHWcRvZPTz8rd1JGG3HzFOau+g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/abort-controller": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
+            "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/config-resolver": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.0.tgz",
+            "integrity": "sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/core": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-k17bgQhVZ7YmUvA8at4af1TDpl0NDMBuBKJl8Yg0nrefwmValU+CnA5l/AriVdQNthU/33H3nK71HrLgqOPr1Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-stream": "^4.2.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/credential-provider-imds": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz",
+            "integrity": "sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz",
+            "integrity": "sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/querystring-builder": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/hash-node": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.2.tgz",
+            "integrity": "sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/invalid-dependency": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz",
+            "integrity": "sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/is-array-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-content-length": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz",
+            "integrity": "sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.0.tgz",
+            "integrity": "sha512-xhLimgNCbCzsUppRTGXWkZywksuTThxaIB0HwbpsVLY5sceac4e1TZ/WKYqufQLaUy+gUSJGNdwD2jo3cXL0iA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.2.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-retry": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.0.tgz",
+            "integrity": "sha512-2zAagd1s6hAaI/ap6SXi5T3dDwBOczOMCSkkYzktqN1+tzbk1GAsHNAdo/1uzxz3Ky02jvZQwbi/vmDA6z4Oyg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/service-error-classification": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz",
+            "integrity": "sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz",
+            "integrity": "sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz",
+            "integrity": "sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
+            "integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/querystring-builder": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/property-provider": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
+            "integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/protocol-http": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
+            "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/querystring-builder": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz",
+            "integrity": "sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/querystring-parser": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz",
+            "integrity": "sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/service-error-classification": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.2.tgz",
+            "integrity": "sha512-LA86xeFpTKn270Hbkixqs5n73S+LVM0/VZco8dqd+JT75Dyx3Lcw/MraL7ybjmz786+160K8rPOmhsq0SocoJQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz",
+            "integrity": "sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/signature-v4": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.2.tgz",
+            "integrity": "sha512-Mz+mc7okA73Lyz8zQKJNyr7lIcHLiPYp0+oiqiMNc/t7/Kf2BENs5d63pEj7oPqdjaum6g0Fc8wC78dY1TgtXw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/smithy-client": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.0.tgz",
+            "integrity": "sha512-Qs65/w30pWV7LSFAez9DKy0Koaoh3iHhpcpCCJ4waj/iqwsuSzJna2+vYwq46yBaqO5ZbP9TjUsATUNxrKeBdw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.2.0",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-stream": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/types": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
+            "integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/url-parser": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.2.tgz",
+            "integrity": "sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-body-length-node": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-buffer-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-config-provider": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.8.tgz",
+            "integrity": "sha512-ZTypzBra+lI/LfTYZeop9UjoJhhGRTg3pxrNpfSTQLd3AJ37r2z4AXTKpq1rFXiiUIJsYyFgNJdjWRGP/cbBaQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.8.tgz",
+            "integrity": "sha512-Rgk0Jc/UDfRTzVthye/k2dDsz5Xxs9LZaKCNPgJTRyoyBoeiNCnHsYGOyu1PKN+sDyPnJzMOz22JbwxzBp9NNA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-endpoints": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.2.tgz",
+            "integrity": "sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-hex-encoding": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-middleware": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.2.tgz",
+            "integrity": "sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-retry": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.2.tgz",
+            "integrity": "sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-stream": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.0.tgz",
+            "integrity": "sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-uri-escape": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-cognito-identity/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/client-docdb": {
@@ -377,6 +1361,60 @@
                 "node": ">=16.0.0"
             }
         },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.777.0.tgz",
+            "integrity": "sha512-lNvz3v94TvEcBvQqVUyg+c/aL3Max+8wUMXvehWoQPv9y9cJAHciZqvA/G+yFo/JB+1Y4IBpMu09W2lfpT6Euw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-cognito-identity": "3.777.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@aws-sdk/types": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
+            "integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/property-provider": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
+            "integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-cognito-identity/node_modules/@smithy/types": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
+            "integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@aws-sdk/credential-provider-env": {
             "version": "3.686.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.686.0.tgz",
@@ -511,6 +1549,969 @@
                 "@aws-sdk/client-sts": "^3.686.0"
             }
         },
+        "node_modules/@aws-sdk/credential-providers": {
+            "version": "3.778.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.778.0.tgz",
+            "integrity": "sha512-Yy1RSBvoDp/iqGDpmgy5/YnSP2ac9NxTv3wdAjKlqVVStlKWU9nG8MPHZRfy01oPNJ5YWZL9stxHjNKC9hg9eg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-cognito-identity": "3.777.0",
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/credential-provider-cognito-identity": "3.777.0",
+                "@aws-sdk/credential-provider-env": "3.775.0",
+                "@aws-sdk/credential-provider-http": "3.775.0",
+                "@aws-sdk/credential-provider-ini": "3.777.0",
+                "@aws-sdk/credential-provider-node": "3.777.0",
+                "@aws-sdk/credential-provider-process": "3.775.0",
+                "@aws-sdk/credential-provider-sso": "3.777.0",
+                "@aws-sdk/credential-provider-web-identity": "3.777.0",
+                "@aws-sdk/nested-clients": "3.777.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/client-sso": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.777.0.tgz",
+            "integrity": "sha512-0+z6CiAYIQa7s6FJ+dpBYPi9zr9yY5jBg/4/FGcwYbmqWPXwL9Thdtr0FearYRZgKl7bhL3m3dILCCfWqr3teQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/middleware-host-header": "3.775.0",
+                "@aws-sdk/middleware-logger": "3.775.0",
+                "@aws-sdk/middleware-recursion-detection": "3.775.0",
+                "@aws-sdk/middleware-user-agent": "3.775.0",
+                "@aws-sdk/region-config-resolver": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.775.0",
+                "@aws-sdk/util-user-agent-browser": "3.775.0",
+                "@aws-sdk/util-user-agent-node": "3.775.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/hash-node": "^4.0.2",
+                "@smithy/invalid-dependency": "^4.0.2",
+                "@smithy/middleware-content-length": "^4.0.2",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-retry": "^4.1.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.8",
+                "@smithy/util-defaults-mode-node": "^4.0.8",
+                "@smithy/util-endpoints": "^3.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/core": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.775.0.tgz",
+            "integrity": "sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/signature-v4": "^5.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.775.0.tgz",
+            "integrity": "sha512-6ESVxwCbGm7WZ17kY1fjmxQud43vzJFoLd4bmlR+idQSWdqlzGDYdcfzpjDKTcivdtNrVYmFvcH1JBUwCRAZhw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.775.0.tgz",
+            "integrity": "sha512-PjDQeDH/J1S0yWV32wCj2k5liRo0ssXMseCBEkCsD3SqsU8o5cU82b0hMX4sAib/RkglCSZqGO0xMiN0/7ndww==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-stream": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.777.0.tgz",
+            "integrity": "sha512-1X9mCuM9JSQPmQ+D2TODt4THy6aJWCNiURkmKmTIPRdno7EIKgAqrr/LLN++K5mBf54DZVKpqcJutXU2jwo01A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/credential-provider-env": "3.775.0",
+                "@aws-sdk/credential-provider-http": "3.775.0",
+                "@aws-sdk/credential-provider-process": "3.775.0",
+                "@aws-sdk/credential-provider-sso": "3.777.0",
+                "@aws-sdk/credential-provider-web-identity": "3.777.0",
+                "@aws-sdk/nested-clients": "3.777.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.777.0.tgz",
+            "integrity": "sha512-ZD66ywx1Q0KyUSuBXZIQzBe3Q7MzX8lNwsrCU43H3Fww+Y+HB3Ncws9grhSdNhKQNeGmZ+MgKybuZYaaeLwJEQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "3.775.0",
+                "@aws-sdk/credential-provider-http": "3.775.0",
+                "@aws-sdk/credential-provider-ini": "3.777.0",
+                "@aws-sdk/credential-provider-process": "3.775.0",
+                "@aws-sdk/credential-provider-sso": "3.777.0",
+                "@aws-sdk/credential-provider-web-identity": "3.777.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.775.0.tgz",
+            "integrity": "sha512-A6k68H9rQp+2+7P7SGO90Csw6nrUEm0Qfjpn9Etc4EboZhhCLs9b66umUsTsSBHus4FDIe5JQxfCUyt1wgNogg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.777.0.tgz",
+            "integrity": "sha512-9mPz7vk9uE4PBVprfINv4tlTkyq1OonNevx2DiXC1LY4mCUCNN3RdBwAY0BTLzj0uyc3k5KxFFNbn3/8ZDQP7w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/client-sso": "3.777.0",
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/token-providers": "3.777.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.777.0.tgz",
+            "integrity": "sha512-uGCqr47fnthkqwq5luNl2dksgcpHHjSXz2jUra7TXtFOpqvnhOW8qXjoa1ivlkq8qhqlaZwCzPdbcN0lXpmLzQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/nested-clients": "3.777.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz",
+            "integrity": "sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz",
+            "integrity": "sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz",
+            "integrity": "sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.775.0.tgz",
+            "integrity": "sha512-7Lffpr1ptOEDE1ZYH1T78pheEY1YmeXWBfFt/amZ6AGsKSLG+JPXvof3ltporTGR2bhH/eJPo7UHCglIuXfzYg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.775.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz",
+            "integrity": "sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/token-providers": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.777.0.tgz",
+            "integrity": "sha512-Yc2cDONsHOa4dTSGOev6Ng2QgTKQUEjaUnsyKd13pc/nLLz/WLqHiQ/o7PcnKERJxXGs1g1C6l3sNXiX+kbnFQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/nested-clients": "3.777.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/types": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
+            "integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.775.0.tgz",
+            "integrity": "sha512-yjWmUgZC9tUxAo8Uaplqmq0eUh0zrbZJdwxGRKdYxfm4RG6fMw1tj52+KkatH7o+mNZvg1GDcVp/INktxonJLw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-endpoints": "^3.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz",
+            "integrity": "sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.775.0.tgz",
+            "integrity": "sha512-N9yhTevbizTOMo3drH7Eoy6OkJ3iVPxhV7dwb6CMAObbLneS36CSfA6xQXupmHWcRvZPTz8rd1JGG3HzFOau+g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/abort-controller": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
+            "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/config-resolver": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.0.tgz",
+            "integrity": "sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/core": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-k17bgQhVZ7YmUvA8at4af1TDpl0NDMBuBKJl8Yg0nrefwmValU+CnA5l/AriVdQNthU/33H3nK71HrLgqOPr1Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-stream": "^4.2.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/credential-provider-imds": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz",
+            "integrity": "sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz",
+            "integrity": "sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/querystring-builder": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/hash-node": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.2.tgz",
+            "integrity": "sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/invalid-dependency": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz",
+            "integrity": "sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/is-array-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-content-length": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz",
+            "integrity": "sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.0.tgz",
+            "integrity": "sha512-xhLimgNCbCzsUppRTGXWkZywksuTThxaIB0HwbpsVLY5sceac4e1TZ/WKYqufQLaUy+gUSJGNdwD2jo3cXL0iA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.2.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-retry": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.0.tgz",
+            "integrity": "sha512-2zAagd1s6hAaI/ap6SXi5T3dDwBOczOMCSkkYzktqN1+tzbk1GAsHNAdo/1uzxz3Ky02jvZQwbi/vmDA6z4Oyg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/service-error-classification": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz",
+            "integrity": "sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz",
+            "integrity": "sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz",
+            "integrity": "sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
+            "integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/querystring-builder": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/property-provider": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
+            "integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/protocol-http": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
+            "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-builder": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz",
+            "integrity": "sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/querystring-parser": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz",
+            "integrity": "sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/service-error-classification": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.2.tgz",
+            "integrity": "sha512-LA86xeFpTKn270Hbkixqs5n73S+LVM0/VZco8dqd+JT75Dyx3Lcw/MraL7ybjmz786+160K8rPOmhsq0SocoJQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz",
+            "integrity": "sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/signature-v4": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.2.tgz",
+            "integrity": "sha512-Mz+mc7okA73Lyz8zQKJNyr7lIcHLiPYp0+oiqiMNc/t7/Kf2BENs5d63pEj7oPqdjaum6g0Fc8wC78dY1TgtXw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/smithy-client": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.0.tgz",
+            "integrity": "sha512-Qs65/w30pWV7LSFAez9DKy0Koaoh3iHhpcpCCJ4waj/iqwsuSzJna2+vYwq46yBaqO5ZbP9TjUsATUNxrKeBdw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.2.0",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-stream": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/types": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
+            "integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/url-parser": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.2.tgz",
+            "integrity": "sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-body-length-node": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-buffer-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-config-provider": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.8.tgz",
+            "integrity": "sha512-ZTypzBra+lI/LfTYZeop9UjoJhhGRTg3pxrNpfSTQLd3AJ37r2z4AXTKpq1rFXiiUIJsYyFgNJdjWRGP/cbBaQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.8.tgz",
+            "integrity": "sha512-Rgk0Jc/UDfRTzVthye/k2dDsz5Xxs9LZaKCNPgJTRyoyBoeiNCnHsYGOyu1PKN+sDyPnJzMOz22JbwxzBp9NNA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-endpoints": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.2.tgz",
+            "integrity": "sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-hex-encoding": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-middleware": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.2.tgz",
+            "integrity": "sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-retry": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.2.tgz",
+            "integrity": "sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-stream": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.0.tgz",
+            "integrity": "sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-uri-escape": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-providers/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@aws-sdk/middleware-host-header": {
             "version": "3.686.0",
             "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.686.0.tgz",
@@ -584,6 +2585,785 @@
             },
             "engines": {
                 "node": ">=16.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.777.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.777.0.tgz",
+            "integrity": "sha512-bmmVRsCjuYlStYPt06hr+f8iEyWg7+AklKCA8ZLDEJujXhXIowgUIqXmqpTkXwkVvDQ9tzU7hxaONjyaQCGybA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-crypto/sha256-browser": "5.2.0",
+                "@aws-crypto/sha256-js": "5.2.0",
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/middleware-host-header": "3.775.0",
+                "@aws-sdk/middleware-logger": "3.775.0",
+                "@aws-sdk/middleware-recursion-detection": "3.775.0",
+                "@aws-sdk/middleware-user-agent": "3.775.0",
+                "@aws-sdk/region-config-resolver": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.775.0",
+                "@aws-sdk/util-user-agent-browser": "3.775.0",
+                "@aws-sdk/util-user-agent-node": "3.775.0",
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/hash-node": "^4.0.2",
+                "@smithy/invalid-dependency": "^4.0.2",
+                "@smithy/middleware-content-length": "^4.0.2",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-retry": "^4.1.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-body-length-node": "^4.0.0",
+                "@smithy/util-defaults-mode-browser": "^4.0.8",
+                "@smithy/util-defaults-mode-node": "^4.0.8",
+                "@smithy/util-endpoints": "^3.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/core": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.775.0.tgz",
+            "integrity": "sha512-8vpW4WihVfz0DX+7WnnLGm3GuQER++b0IwQG35JlQMlgqnc44M//KbJPsIHA0aJUJVwJAEShgfr5dUbY8WUzaA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/signature-v4": "^5.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "fast-xml-parser": "4.4.1",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-host-header": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.775.0.tgz",
+            "integrity": "sha512-tkSegM0Z6WMXpLB8oPys/d+umYIocvO298mGvcMCncpRl77L9XkvSLJIFzaHes+o7djAgIduYw8wKIMStFss2w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-logger": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.775.0.tgz",
+            "integrity": "sha512-FaxO1xom4MAoUJsldmR92nT1G6uZxTdNYOFYtdHfd6N2wcNaTuxgjIvqzg5y7QIH9kn58XX/dzf1iTjgqUStZw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-recursion-detection": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.775.0.tgz",
+            "integrity": "sha512-GLCzC8D0A0YDG5u3F5U03Vb9j5tcOEFhr8oc6PDk0k0vm5VwtZOE6LvK7hcCSoAB4HXyOUM0sQuXrbaAh9OwXA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/middleware-user-agent": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.775.0.tgz",
+            "integrity": "sha512-7Lffpr1ptOEDE1ZYH1T78pheEY1YmeXWBfFt/amZ6AGsKSLG+JPXvof3ltporTGR2bhH/eJPo7UHCglIuXfzYg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@aws-sdk/util-endpoints": "3.775.0",
+                "@smithy/core": "^3.2.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/region-config-resolver": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.775.0.tgz",
+            "integrity": "sha512-40iH3LJjrQS3LKUJAl7Wj0bln7RFPEvUYKFxtP8a+oKFDO0F65F52xZxIJbPn6sHkxWDAnZlGgdjZXM3p2g5wQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/types": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.775.0.tgz",
+            "integrity": "sha512-ZoGKwa4C9fC9Av6bdfqcW6Ix5ot05F/S4VxWR2nHuMv7hzfmAjTOcUiWT7UR4hM/U0whf84VhDtXN/DWAk52KA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.775.0.tgz",
+            "integrity": "sha512-yjWmUgZC9tUxAo8Uaplqmq0eUh0zrbZJdwxGRKdYxfm4RG6fMw1tj52+KkatH7o+mNZvg1GDcVp/INktxonJLw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-endpoints": "^3.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-browser": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.775.0.tgz",
+            "integrity": "sha512-txw2wkiJmZKVdDbscK7VBK+u+TJnRtlUjRTLei+elZg2ADhpQxfVAQl436FUeIv6AhB/oRHW6/K/EAGXUSWi0A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/types": "^4.2.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-user-agent-node": {
+            "version": "3.775.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.775.0.tgz",
+            "integrity": "sha512-N9yhTevbizTOMo3drH7Eoy6OkJ3iVPxhV7dwb6CMAObbLneS36CSfA6xQXupmHWcRvZPTz8rd1JGG3HzFOau+g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-user-agent": "3.775.0",
+                "@aws-sdk/types": "3.775.0",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "peerDependencies": {
+                "aws-crt": ">=1.0.0"
+            },
+            "peerDependenciesMeta": {
+                "aws-crt": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/abort-controller": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.0.2.tgz",
+            "integrity": "sha512-Sl/78VDtgqKxN2+1qduaVE140XF+Xg+TafkncspwM4jFP/LHr76ZHmIY/y3V1M0mMLNk+Je6IGbzxy23RSToMw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/config-resolver": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.1.0.tgz",
+            "integrity": "sha512-8smPlwhga22pwl23fM5ew4T9vfLUCeFXlcqNOCD5M5h8VmNPNUE9j6bQSuRXpDSV11L/E/SwEBQuW8hr6+nS1A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-config-provider": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/core": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.2.0.tgz",
+            "integrity": "sha512-k17bgQhVZ7YmUvA8at4af1TDpl0NDMBuBKJl8Yg0nrefwmValU+CnA5l/AriVdQNthU/33H3nK71HrLgqOPr1Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-body-length-browser": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-stream": "^4.2.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/credential-provider-imds": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.2.tgz",
+            "integrity": "sha512-32lVig6jCaWBHnY+OEQ6e6Vnt5vDHaLiydGrwYMW9tPqO688hPGTYRamYJ1EptxEC2rAwJrHWmPoKRBl4iTa8w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/fetch-http-handler": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.0.2.tgz",
+            "integrity": "sha512-+9Dz8sakS9pe7f2cBocpJXdeVjMopUDLgZs1yWeu7h++WqSbjUYv/JAJwKwXw1HV6gq1jyWjxuyn24E2GhoEcQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/querystring-builder": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-base64": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/hash-node": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.0.2.tgz",
+            "integrity": "sha512-VnTpYPnRUE7yVhWozFdlxcYknv9UN7CeOqSrMH+V877v4oqtVYuoqhIhtSjmGPvYrYnAkaM61sLMKHvxL138yg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/invalid-dependency": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.0.2.tgz",
+            "integrity": "sha512-GatB4+2DTpgWPday+mnUkoumP54u/MDM/5u44KF9hIu8jF0uafZtQLcdfIKkIcUNuF/fBojpLEHZS/56JqPeXQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/is-array-buffer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.0.0.tgz",
+            "integrity": "sha512-saYhF8ZZNoJDTvJBEWgeBccCg+yvp1CX+ed12yORU3NilJScfc6gfch2oVb4QgxZrGUx3/ZJlb+c/dJbyupxlw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-content-length": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.0.2.tgz",
+            "integrity": "sha512-hAfEXm1zU+ELvucxqQ7I8SszwQ4znWMbNv6PLMndN83JJN41EPuS93AIyh2N+gJ6x8QFhzSO6b7q2e6oClDI8A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-endpoint": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.0.tgz",
+            "integrity": "sha512-xhLimgNCbCzsUppRTGXWkZywksuTThxaIB0HwbpsVLY5sceac4e1TZ/WKYqufQLaUy+gUSJGNdwD2jo3cXL0iA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.2.0",
+                "@smithy/middleware-serde": "^4.0.3",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "@smithy/url-parser": "^4.0.2",
+                "@smithy/util-middleware": "^4.0.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-retry": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.0.tgz",
+            "integrity": "sha512-2zAagd1s6hAaI/ap6SXi5T3dDwBOczOMCSkkYzktqN1+tzbk1GAsHNAdo/1uzxz3Ky02jvZQwbi/vmDA6z4Oyg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/service-error-classification": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-retry": "^4.0.2",
+                "tslib": "^2.6.2",
+                "uuid": "^9.0.1"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-serde": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.0.3.tgz",
+            "integrity": "sha512-rfgDVrgLEVMmMn0BI8O+8OVr6vXzjV7HZj57l0QxslhzbvVfikZbVfBVthjLHqib4BW44QhcIgJpvebHlRaC9A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/middleware-stack": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.0.2.tgz",
+            "integrity": "sha512-eSPVcuJJGVYrFYu2hEq8g8WWdJav3sdrI4o2c6z/rjnYDd3xH9j9E7deZQCzFn4QvGPouLngH3dQ+QVTxv5bOQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-config-provider": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.0.2.tgz",
+            "integrity": "sha512-WgCkILRZfJwJ4Da92a6t3ozN/zcvYyJGUTmfGbgS/FkCcoCjl7G4FJaCDN1ySdvLvemnQeo25FdkyMSTSwulsw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/shared-ini-file-loader": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/node-http-handler": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.0.4.tgz",
+            "integrity": "sha512-/mdqabuAT3o/ihBGjL94PUbTSPSRJ0eeVTdgADzow0wRJ0rN4A27EOrtlK56MYiO1fDvlO3jVTCxQtQmK9dZ1g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/abort-controller": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/querystring-builder": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/property-provider": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.0.2.tgz",
+            "integrity": "sha512-wNRoQC1uISOuNc2s4hkOYwYllmiyrvVXWMtq+TysNRVQaHm4yoafYQyjN/goYZS+QbYlPIbb/QRjaUZMuzwQ7A==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/protocol-http": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.1.0.tgz",
+            "integrity": "sha512-KxAOL1nUNw2JTYrtviRRjEnykIDhxc84qMBzxvu1MUfQfHTuBlCG7PA6EdVwqpJjH7glw7FqQoFxUJSyBQgu7g==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-builder": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.0.2.tgz",
+            "integrity": "sha512-NTOs0FwHw1vimmQM4ebh+wFQvOwkEf/kQL6bSM1Lock+Bv4I89B3hGYoUEPkmvYPkDKyp5UdXJYu+PoTQ3T31Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/querystring-parser": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.0.2.tgz",
+            "integrity": "sha512-v6w8wnmZcVXjfVLjxw8qF7OwESD9wnpjp0Dqry/Pod0/5vcEA3qxCr+BhbOHlxS8O+29eLpT3aagxXGwIoEk7Q==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/service-error-classification": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.0.2.tgz",
+            "integrity": "sha512-LA86xeFpTKn270Hbkixqs5n73S+LVM0/VZco8dqd+JT75Dyx3Lcw/MraL7ybjmz786+160K8rPOmhsq0SocoJQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/shared-ini-file-loader": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.0.2.tgz",
+            "integrity": "sha512-J9/gTWBGVuFZ01oVA6vdb4DAjf1XbDhK6sLsu3OS9qmLrS6KB5ygpeHiM3miIbj1qgSJ96GYszXFWv6ErJ8QEw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/signature-v4": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.0.2.tgz",
+            "integrity": "sha512-Mz+mc7okA73Lyz8zQKJNyr7lIcHLiPYp0+oiqiMNc/t7/Kf2BENs5d63pEj7oPqdjaum6g0Fc8wC78dY1TgtXw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-middleware": "^4.0.2",
+                "@smithy/util-uri-escape": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/smithy-client": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.2.0.tgz",
+            "integrity": "sha512-Qs65/w30pWV7LSFAez9DKy0Koaoh3iHhpcpCCJ4waj/iqwsuSzJna2+vYwq46yBaqO5ZbP9TjUsATUNxrKeBdw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.2.0",
+                "@smithy/middleware-endpoint": "^4.1.0",
+                "@smithy/middleware-stack": "^4.0.2",
+                "@smithy/protocol-http": "^5.1.0",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-stream": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/types": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.2.0.tgz",
+            "integrity": "sha512-7eMk09zQKCO+E/ivsjQv+fDlOupcFUCSC/L2YUPgwhvowVGWbPQHjEFcmjt7QQ4ra5lyowS92SV53Zc6XD4+fg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/url-parser": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.0.2.tgz",
+            "integrity": "sha512-Bm8n3j2ScqnT+kJaClSVCMeiSenK6jVAzZCNewsYWuZtnBehEz4r2qP0riZySZVfzB+03XZHJeqfmJDkeeSLiQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/querystring-parser": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-base64": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.0.0.tgz",
+            "integrity": "sha512-CvHfCmO2mchox9kjrtzoHkWHxjHZzaFojLc8quxXY7WAAMAg43nuxwv95tATVgQFNDwd4M9S1qFzj40Ul41Kmg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-browser": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.0.0.tgz",
+            "integrity": "sha512-sNi3DL0/k64/LO3A256M+m3CDdG6V7WKWHdAiBBMUN8S3hK3aMPhwnPik2A/a2ONN+9doY9UxaLfgqsIRg69QA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-body-length-node": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.0.0.tgz",
+            "integrity": "sha512-q0iDP3VsZzqJyje8xJWEJCNIu3lktUGVoSy1KB0UWym2CL1siV3artm+u1DFYTLejpsrdGyCSWBdGNjJzfDPjg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-buffer-from": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.0.0.tgz",
+            "integrity": "sha512-9TOQ7781sZvddgO8nxueKi3+yGvkY35kotA0Y6BWRajAv8jjmigQ1sBwz0UX47pQMYXJPahSKEKYFgt+rXdcug==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/is-array-buffer": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-config-provider": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.0.0.tgz",
+            "integrity": "sha512-L1RBVzLyfE8OXH+1hsJ8p+acNUSirQnWQ6/EgpchV88G6zGBTDPdXiiExei6Z1wR2RxYvxY/XLw6AMNCCt8H3w==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-browser": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.8.tgz",
+            "integrity": "sha512-ZTypzBra+lI/LfTYZeop9UjoJhhGRTg3pxrNpfSTQLd3AJ37r2z4AXTKpq1rFXiiUIJsYyFgNJdjWRGP/cbBaQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-defaults-mode-node": {
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.8.tgz",
+            "integrity": "sha512-Rgk0Jc/UDfRTzVthye/k2dDsz5Xxs9LZaKCNPgJTRyoyBoeiNCnHsYGOyu1PKN+sDyPnJzMOz22JbwxzBp9NNA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/config-resolver": "^4.1.0",
+                "@smithy/credential-provider-imds": "^4.0.2",
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/property-provider": "^4.0.2",
+                "@smithy/smithy-client": "^4.2.0",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-endpoints": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.0.2.tgz",
+            "integrity": "sha512-6QSutU5ZyrpNbnd51zRTL7goojlcnuOB55+F9VBD+j8JpRY50IGamsjlycrmpn8PQkmJucFW8A0LSfXj7jjtLQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/node-config-provider": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-hex-encoding": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.0.0.tgz",
+            "integrity": "sha512-Yk5mLhHtfIgW2W2WQZWSg5kuMZCVbvhFmC7rV4IO2QqnZdbEFPmQnCcGMAX2z/8Qj3B9hYYNjZOhWym+RwhePw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-middleware": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.0.2.tgz",
+            "integrity": "sha512-6GDamTGLuBQVAEuQ4yDQ+ti/YINf/MEmIegrEeg7DdB/sld8BX1lqt9RRuIcABOhAGTA50bRbPzErez7SlDtDQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-retry": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.0.2.tgz",
+            "integrity": "sha512-Qryc+QG+7BCpvjloFLQrmlSd0RsVRHejRXd78jNO3+oREueCjwG1CCEH1vduw/ZkM1U9TztwIKVIi3+8MJScGg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/service-error-classification": "^4.0.2",
+                "@smithy/types": "^4.2.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-stream": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.2.0.tgz",
+            "integrity": "sha512-Vj1TtwWnuWqdgQI6YTUF5hQ/0jmFiOYsc51CSMgj7QfyO+RF4EnT2HNjoviNlOOmgzgvf3f5yno+EiC4vrnaWQ==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/fetch-http-handler": "^5.0.2",
+                "@smithy/node-http-handler": "^4.0.4",
+                "@smithy/types": "^4.2.0",
+                "@smithy/util-base64": "^4.0.0",
+                "@smithy/util-buffer-from": "^4.0.0",
+                "@smithy/util-hex-encoding": "^4.0.0",
+                "@smithy/util-utf8": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-uri-escape": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.0.0.tgz",
+            "integrity": "sha512-77yfbCbQMtgtTylO9itEAdpPXSog3ZxMe09AEhm0dU0NLTalV70ghDZFR+Nfi1C60jnJoh/Re4090/DuZh2Omg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@smithy/util-utf8": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.0.0.tgz",
+            "integrity": "sha512-b+zebfKCfRdgNJDknHCob3O7FpeYQN6ZG6YLExMcasDHsCXlsXCEuiPZeLnJLpwa5dvPetGlnGCiMHuLwGvFow==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/util-buffer-from": "^4.0.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
             }
         },
         "node_modules/@aws-sdk/region-config-resolver": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
             "relationships": {
                 "entityNameSeparator": "."
             },
-			"checkAwsCredentials": true
+            "checkAwsCredentials": true
         }
     },
     "description": "Hackolade plugin for Amazon DocumentDB",
@@ -63,6 +63,7 @@
     },
     "dependencies": {
         "@aws-sdk/client-docdb": "3.687.0",
+        "@aws-sdk/credential-providers": "3.778.0",
         "@hackolade/fetch": "1.1.0",
         "async": "3.2.6",
         "bson": "1.1.6",

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -49,6 +49,11 @@ module.exports = {
 		});
 
 		try {
+			logger.clear();
+
+			log.info(getSystemInfo(connectionInfo.appVersion));
+			log.info(connectionInfo, 'connectionInfo');
+
 			await getDocDbClientInstance({
 				connectionInfo: {
 					...connectionInfo,
@@ -56,10 +61,6 @@ module.exports = {
 				},
 				logger: log,
 			});
-
-			logger.clear();
-			log.info(getSystemInfo(connectionInfo.appVersion));
-			log.info(connectionInfo, 'connectionInfo');
 
 			const includeSystemCollection = connectionInfo.includeSystemCollection;
 			const connection = await connectionHelper.connect(connectionInfo, sshService);

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -49,11 +49,12 @@ module.exports = {
 		});
 
 		try {
-			getDocDbClientInstance({
+			await getDocDbClientInstance({
 				connectionInfo: {
 					...connectionInfo,
 					...parseHost(connectionInfo.host, log),
 				},
+				logger: log,
 			});
 
 			logger.clear();
@@ -120,7 +121,7 @@ module.exports = {
 			const query = safeParse(data.queryCriteria);
 			const sort = safeParse(data.sortCriteria);
 			const maxTimeMS = Number(data.queryRequestTimeout) || 120000;
-			const docDbClientInstance = getDocDbClientInstance();
+			const docDbClientInstance = await getDocDbClientInstance({ logger: log });
 
 			log.info({
 				title: 'Parameters',

--- a/shared/getDocDbClientInstance.js
+++ b/shared/getDocDbClientInstance.js
@@ -1,24 +1,44 @@
 const { head } = require('lodash');
+const { fromIni } = require('@aws-sdk/credential-providers');
 const { DocDBClient, DescribeDBClustersCommand, ListTagsForResourceCommand } = require('@aws-sdk/client-docdb');
 const { hckFetchAwsSdkHttpHandler } = require('@hackolade/fetch');
 
 let instance = null;
 
-const getDocDbClientInstance = ({ connectionInfo = {} } = {}) => {
+const getCredentials = async ({ connectionInfo = {}, logger = {} }) => {
+	const { accessKeyId, secretAccessKey, sessionToken } = connectionInfo;
+
+	if (!accessKeyId || !secretAccessKey) {
+		logger.info(`'Access Key ID' or 'Secret Access Key' were not specified, checking system AWS credentials...`);
+		try {
+			return await fromIni()();
+		} catch (error) {
+			logger.error(error);
+			return {};
+		}
+	}
+
+	if (sessionToken) {
+		logger.info(`AWS session token provided, including it into credentials.`);
+	}
+
+	return {
+		accessKeyId,
+		secretAccessKey,
+		sessionToken,
+	};
+};
+
+const getDocDbClientInstance = async ({ connectionInfo = {}, logger } = {}) => {
 	if (instance) {
 		return instance;
 	}
 
-	const { region, accessKeyId, secretAccessKey, sessionToken, queryRequestTimeout, dbClusterIdentifier } =
-		connectionInfo;
+	const { region, queryRequestTimeout, dbClusterIdentifier } = connectionInfo;
 
 	const docDbClient = new DocDBClient({
 		region,
-		credentials: {
-			accessKeyId,
-			secretAccessKey,
-			sessionToken,
-		},
+		credentials: await getCredentials({ connectionInfo, logger }),
 		requestHandler: hckFetchAwsSdkHttpHandler({ requestTimeout: queryRequestTimeout }),
 	});
 

--- a/shared/getDocDbClientInstance.js
+++ b/shared/getDocDbClientInstance.js
@@ -6,12 +6,19 @@ const { hckFetchAwsSdkHttpHandler } = require('@hackolade/fetch');
 let instance = null;
 
 const getCredentials = async ({ connectionInfo = {}, logger = {} }) => {
+	const logSessionToken = () => logger.info(`AWS session token provided, including it into credentials.`);
+
 	const { accessKeyId, secretAccessKey, sessionToken } = connectionInfo;
 
 	if (!accessKeyId || !secretAccessKey) {
 		logger.info(`'Access Key ID' or 'Secret Access Key' were not specified, checking system AWS credentials...`);
 		try {
-			return await fromIni()();
+			const credentials = await fromIni()();
+			logger.info('AWS credentials were successfully obtained from the file.');
+			if (credentials.sessionToken) {
+				logSessionToken();
+			}
+			return credentials;
 		} catch (error) {
 			logger.error(error);
 			return {};
@@ -19,7 +26,7 @@ const getCredentials = async ({ connectionInfo = {}, logger = {} }) => {
 	}
 
 	if (sessionToken) {
-		logger.info(`AWS session token provided, including it into credentials.`);
+		logSessionToken();
 	}
 
 	return {


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-10566" title="HCK-10566" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-10566</a>  Add connection info in logs: credentials file used?  Session token used?
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Technical details

* extended the mechanism of getting AWS credentials, making it more explicit in the logs:

  * when there were no AWS credentials in Connection Config:
  ```
  2025-04-01T16:55:16.268Z Retrieving databases and collections information:
  'Access Key ID' or 'Secret Access Key' were not specified, checking system AWS credentials...

  2025-04-01T16:55:16.270Z Retrieving databases and collections information:
  AWS credentials were successfully obtained from the file.
  ```
  * when there were no AWS credentials in Connection Config and the AWS credential file is not recognized:
  ```
  2025-04-01T16:58:19.617Z Retrieving databases and collections information:
  'Access Key ID' or 'Secret Access Key' were not specified, checking system AWS credentials...

  2025-04-01T16:58:19.619Z Retrieving databases and collections information:
  {
  "message": "Could not resolve credentials using profile: [default] in configuration/credentials file(s).",
  "stack": "CredentialsProviderError: Could not resolve credentials using profile: [default] in configuration/credentials file(s).
    at resolveProfileData (/home/oleg/.hackolade/plugins/DocumentDB/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini/dist-cjs/index.js:246:9)
    at /home/oleg/.hackolade/plugins/DocumentDB/node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/credential-provider-ini/dist-cjs/index.js:263:10
    at async getCredentials (/home/oleg/.hackolade/plugins/DocumentDB/shared/getDocDbClientInstance.js:16:24)
    at async getDocDbClientInstance (/home/oleg/.hackolade/plugins/DocumentDB/shared/getDocDbClientInstance.js:48:16)
    at async Object.getDbCollectionsNames (/home/oleg/.hackolade/plugins/DocumentDB/reverse_engineering/api.js:57:4)
    at async callApiHandler (/home/oleg/Documents/hackolade/studio/dist-dev/reWorker.js:92:3)
    at async EventEmitter.<anonymous> (/home/oleg/Documents/hackolade/studio/dist-dev/reWorker.js:219:5)"
  }
  ```

  * when everything, related to AWS credentials, were provided, including the session token:
  ```
  2025-04-01T17:00:32.618Z Retrieving databases and collections information:
  AWS session token provided, including it into credentials.
  ```